### PR TITLE
Fix map validation crash on boundary cells

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -45,9 +45,9 @@ int		is_map_line(char *line);
 void	free_split(char **tab);
 int		parse_color(char *line, t_config *cfg, int is_floor,
 			t_parse_ctx *ctx);
-int		parse_texture(char *line, char **store, t_parse_ctx *ctx,
+t_state_parsing	parse_texture(char *line, char **store, t_parse_ctx *ctx,
 			char *label);
-int		parse_map(char **lines, int start, t_config *cfg,
+t_state_parsing	parse_map(char **lines, int start, t_config *cfg,
 			t_parse_ctx *ctx);
 void	validate_map(t_config *cfg, t_parse_ctx *ctx);
 void	free_config(t_config *cfg);

--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -58,7 +58,7 @@ static int	parse_config(char **lines, t_config *cfg, t_parse_ctx *ctx)
 	{
 		if (is_empty_line(lines[i]))
 			i++;
-		else if (handle_line(lines[i], cfg, ctx) == 0)
+		else if (handle_line(lines[i], cfg, ctx) == PARSING_SUCCESS)
 			i++;
 		else if (is_map_line(lines[i]))
 			return (i);
@@ -90,7 +90,7 @@ void	parse_file(const char *file, t_config *cfg)
 	ctx.lines = lines;
 	map_start = parse_config(lines, cfg, &ctx);
 	ensure_required_config(cfg, &ctx);
-	if (parse_map(lines, map_start, cfg, &ctx) < 0)
+	if (parse_map(lines, map_start, cfg, &ctx) != PARSING_SUCCESS)
 		parse_error("Map error", &ctx);
 	validate_map(cfg, &ctx);
 	free_split(lines);

--- a/srcs/parse/validate_map.c
+++ b/srcs/parse/validate_map.c
@@ -12,27 +12,30 @@
 
 #include "parse.h"
 
-static int	is_outside(t_config *cfg, int x, int y)
+static char     cell_at(t_config *cfg, int x, int y)
 {
-	return (x < 0 || y < 0 || x >= cfg->map.width || y >= cfg->map.height);
+	if (x < 0 || y < 0)
+		return (' ');
+	if (x >= cfg->map.width || y >= cfg->map.height)
+		return (' ');
+	return (cfg->map.grid[y][x]);
 }
 
-static void	check_cell(t_config *cfg, int x, int y, t_parse_ctx *ctx)
+static void     check_cell(t_config *cfg, int x, int y, t_parse_ctx *ctx)
 {
-	if (cfg->map.grid[y][x] != '0')
+	if (cell_at(cfg, x, y) != '0')
 		return ;
-	if (is_outside(cfg, x - 1, y) || is_outside(cfg, x + 1, y)
-		|| is_outside(cfg, x, y - 1) || is_outside(cfg, x, y + 1))
-		parse_error("Map not closed", ctx);
-	if (cfg->map.grid[y - 1][x] == ' ' || cfg->map.grid[y + 1][x] == ' '
-		|| cfg->map.grid[y][x - 1] == ' ' || cfg->map.grid[y][x + 1] == ' ')
+	if (cell_at(cfg, x - 1, y) == ' '
+		|| cell_at(cfg, x + 1, y) == ' '
+		|| cell_at(cfg, x, y - 1) == ' '
+		|| cell_at(cfg, x, y + 1) == ' ')
 		parse_error("Map not closed", ctx);
 }
 
-void	validate_map(t_config *cfg, t_parse_ctx *ctx)
+void    validate_map(t_config *cfg, t_parse_ctx *ctx)
 {
-	int	x;
-	int	y;
+	int     x;
+	int     y;
 
 	if (!cfg->player.dir)
 		parse_error("Player missing", ctx);


### PR DESCRIPTION
## Summary
- propagate the `t_state_parsing` enum for texture and map parsing to avoid implicit integer checks
- harden map validation by safely sampling neighbour cells before checking boundaries

## Testing
- make CC=gcc
- ./cub3D maps/exemple.cub
- ./cub3D maps/wrong_map.cub

------
https://chatgpt.com/codex/tasks/task_e_68da8bee8e5c83299aa46cf9671eeb16